### PR TITLE
Fix consistency problems with examples

### DIFF
--- a/sections/authentication.md
+++ b/sections/authentication.md
@@ -20,7 +20,7 @@ OAuth 2
 
 1. Register your application with Image Relay. You need an Image Relay account to do this. Once logged in to IR, click on "My Account" in the upper right corner. Select "Developers" from the menu on the left. You'll need to provide your application name and a callback URI. Please note - you need a __paid__ Image Relay account to do this.
 
- - The callback URI specified in the configuration must point to a web service or something that is capable of receiving a web request. The request will contain a code that you will use to exchange for an authorization token. https://webhook.site/ is a nice alternative if you are setting this up for the first time.
+ - The callback URI specified in the configuration must point to a web service or something that is capable of receiving a web request. The request will contain a code that you will use to exchange for an authorization token. https://webhook.site/ is a nice alternative if you are setting this up for the first time. **NOTE** If you use the webhook site, make sure to copy the URL from the page, _not your address bar_. 
 
 2. To begin the process of obtaining an OAuth token, visit the authorization endpoint in a web browser - https://<YOUR_IR_SUBDOMAIN>.imagerelay.com/oauth/authorize...... Below is an example of the full constructed URL.
 
@@ -28,7 +28,7 @@ OAuth 2
 
 3. Upon visiting that URL you will need to login. Once you are logged in, Click the 'Yes give them access button' to grant access and then you will be redirected to the redirect uri that you specified when configuring the application (it should match the redirect_uri param in the url from step 2)
 
-4. Your web service will have received a request with a `code` parameter and value. 
+4. Your web service will have received a request with a `code` parameter and value. If you're using webhook.site, this will be the first request made on the left hand panel. Select that, then get the ID Token value from the request body.
 
 5. Now use the code that your web service received in step 4 to obtain an access token. You can use CURL to perform this request or some other API testing tool of your choosing.
 

--- a/sections/file_types.md
+++ b/sections/file_types.md
@@ -3,6 +3,8 @@ File Types
 
 Each file in Image Relay is assigned a file type. Different file types have different sets of metadata associated with them.
 
+Note that on the web, this is known as a Metadata Template. Not all plans have the ability to create new templates and alter the terms associated with your default template. Please contact support@imagerelay.com if you have questions about your plan features.
+
 Get File Types
 --------------
 
@@ -76,7 +78,7 @@ Get File Type
  "description":"A File Type",
  "created_on":"2008-05-18T20:16:52Z"
  ,"updated_on":"2013-01-07T17:06:14Z",
- "id":149,
+ "id":555,
  "terms":
    [
      {

--- a/sections/folder_links.md
+++ b/sections/folder_links.md
@@ -50,7 +50,7 @@ Get Folder Link
 
 ```json
 {
-  "id": 52,
+  "id": 555,
   "uid": "b9d1a51601624f67a055f663c5852f24",
   "user_id": 405,
   "purpose": "testing api creation",

--- a/sections/folders.md
+++ b/sections/folders.md
@@ -103,12 +103,13 @@ Get Folder
 
 ```json
 {
-  "created_on":"2012-06-19T08:41:19Z",
-  "id":11136,"metagroup_id":null,
+  "id":555,
+  "metagroup_id":null,
   "name":"McCadam Logos",
   "parent_id":6527,
-  "updated_on":"2012-07-23T15:39:16Z",
   "user_id":405
+  "created_on":"2012-06-19T08:41:19Z",
+  "updated_on":"2012-07-23T15:39:16Z",
 }
 ```
 

--- a/sections/users.md
+++ b/sections/users.md
@@ -48,7 +48,7 @@ Get User
 
 ```json
 {
-    "id": 405,
+    "id": 20,
     "login": "login",
     "first_name": "First Name",
     "last_name": "Last Name",


### PR DESCRIPTION
Fix ID mismatches between example URLs and example response bodies.

Add more clarity around what file types are, and how not all client plans have access to create new file types, or modify the terms on an existing file type.

Improve OAuth instructions for webhook.site users