### PR TITLE
we have a never expiring invite url now

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Want to Chat?
 -------------
 Need help, have questions? Visit our API discussion Slack channel here: [slack channel](https://ir-dev.slack.com/)
 
-If you haven't already created an account, [you can do so via this link](https://imagerelay-dev-slackin.herokuapp.com/)
+If you haven't already created an account, [you can do so via this link](https://ir-dev.slack.com/join/shared_invite/zt-dfefct07-S3ZEege2vZmJXbDG1GqS7A)


### PR DESCRIPTION
Drew alerted me to a (new?) Slack feature to generate invite URLs, so I popped into settings and generated a never-expiring invite URL